### PR TITLE
Rename to @feathersjs/transport-commons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,254 +1,254 @@
 # Change Log
 
-## [v3.1.5](https://github.com/feathersjs/socket-commons/tree/v3.1.5) (2017-12-12)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v3.1.4...v3.1.5)
+## [v3.1.5](https://github.com/feathersjs/transport-commons/tree/v3.1.5) (2017-12-12)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v3.1.4...v3.1.5)
 
-## [v3.1.4](https://github.com/feathersjs/socket-commons/tree/v3.1.4) (2017-12-12)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v3.1.3...v3.1.4)
-
-**Merged pull requests:**
-
-- Fix dispatching of arrays [\#62](https://github.com/feathersjs/socket-commons/pull/62) ([daffl](https://github.com/daffl))
-
-## [v3.1.3](https://github.com/feathersjs/socket-commons/tree/v3.1.3) (2017-12-12)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v3.1.2...v3.1.3)
+## [v3.1.4](https://github.com/feathersjs/transport-commons/tree/v3.1.4) (2017-12-12)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v3.1.3...v3.1.4)
 
 **Merged pull requests:**
 
-- Make sure that each entry in an array is dispatched as its own even [\#61](https://github.com/feathersjs/socket-commons/pull/61) ([daffl](https://github.com/daffl))
+- Fix dispatching of arrays [\#62](https://github.com/feathersjs/transport-commons/pull/62) ([daffl](https://github.com/daffl))
 
-## [v3.1.2](https://github.com/feathersjs/socket-commons/tree/v3.1.2) (2017-12-06)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v3.1.1...v3.1.2)
-
-**Merged pull requests:**
-
-- Fix another error when there are no results [\#60](https://github.com/feathersjs/socket-commons/pull/60) ([daffl](https://github.com/daffl))
-
-## [v3.1.1](https://github.com/feathersjs/socket-commons/tree/v3.1.1) (2017-12-06)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v3.1.0...v3.1.1)
+## [v3.1.3](https://github.com/feathersjs/transport-commons/tree/v3.1.3) (2017-12-12)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v3.1.2...v3.1.3)
 
 **Merged pull requests:**
 
-- Always use a combined channel [\#59](https://github.com/feathersjs/socket-commons/pull/59) ([daffl](https://github.com/daffl))
+- Make sure that each entry in an array is dispatched as its own even [\#61](https://github.com/feathersjs/transport-commons/pull/61) ([daffl](https://github.com/daffl))
 
-## [v3.1.0](https://github.com/feathersjs/socket-commons/tree/v3.1.0) (2017-12-06)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v3.0.1...v3.1.0)
+## [v3.1.2](https://github.com/feathersjs/transport-commons/tree/v3.1.2) (2017-12-06)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v3.1.1...v3.1.2)
 
 **Merged pull requests:**
 
-- Give channel dispatchers a precedence [\#58](https://github.com/feathersjs/socket-commons/pull/58) ([daffl](https://github.com/daffl))
+- Fix another error when there are no results [\#60](https://github.com/feathersjs/transport-commons/pull/60) ([daffl](https://github.com/daffl))
 
-## [v3.0.1](https://github.com/feathersjs/socket-commons/tree/v3.0.1) (2017-11-03)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v3.0.0...v3.0.1)
+## [v3.1.1](https://github.com/feathersjs/transport-commons/tree/v3.1.1) (2017-12-06)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v3.1.0...v3.1.1)
+
+**Merged pull requests:**
+
+- Always use a combined channel [\#59](https://github.com/feathersjs/transport-commons/pull/59) ([daffl](https://github.com/daffl))
+
+## [v3.1.0](https://github.com/feathersjs/transport-commons/tree/v3.1.0) (2017-12-06)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v3.0.1...v3.1.0)
+
+**Merged pull requests:**
+
+- Give channel dispatchers a precedence [\#58](https://github.com/feathersjs/transport-commons/pull/58) ([daffl](https://github.com/daffl))
+
+## [v3.0.1](https://github.com/feathersjs/transport-commons/tree/v3.0.1) (2017-11-03)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v3.0.0...v3.0.1)
 
 **Closed issues:**
 
-- Allow socket calls without params and callback [\#54](https://github.com/feathersjs/socket-commons/issues/54)
+- Allow socket calls without params and callback [\#54](https://github.com/feathersjs/transport-commons/issues/54)
 
 **Merged pull requests:**
 
-- Allow socket calls without query and callback [\#55](https://github.com/feathersjs/socket-commons/pull/55) ([daffl](https://github.com/daffl))
+- Allow socket calls without query and callback [\#55](https://github.com/feathersjs/transport-commons/pull/55) ([daffl](https://github.com/daffl))
 
-## [v3.0.0](https://github.com/feathersjs/socket-commons/tree/v3.0.0) (2017-11-01)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v3.0.0-pre.7...v3.0.0)
+## [v3.0.0](https://github.com/feathersjs/transport-commons/tree/v3.0.0) (2017-11-01)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v3.0.0-pre.7...v3.0.0)
 
-## [v3.0.0-pre.7](https://github.com/feathersjs/socket-commons/tree/v3.0.0-pre.7) (2017-10-25)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v3.0.0-pre.6...v3.0.0-pre.7)
+## [v3.0.0-pre.7](https://github.com/feathersjs/transport-commons/tree/v3.0.0-pre.7) (2017-10-25)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v3.0.0-pre.6...v3.0.0-pre.7)
 
 **Merged pull requests:**
 
-- Update to better returnHook handling [\#53](https://github.com/feathersjs/socket-commons/pull/53) ([daffl](https://github.com/daffl))
+- Update to better returnHook handling [\#53](https://github.com/feathersjs/transport-commons/pull/53) ([daffl](https://github.com/daffl))
 
-## [v3.0.0-pre.6](https://github.com/feathersjs/socket-commons/tree/v3.0.0-pre.6) (2017-10-21)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v3.0.0-pre.5...v3.0.0-pre.6)
+## [v3.0.0-pre.6](https://github.com/feathersjs/transport-commons/tree/v3.0.0-pre.6) (2017-10-21)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v3.0.0-pre.5...v3.0.0-pre.6)
 
 **Closed issues:**
 
-- feathers-socket-commons produces error when it get bundled and steal-socket.io gets used as connection [\#44](https://github.com/feathersjs/socket-commons/issues/44)
-- Surface src/events.js lines 44-69 for feathers-hooks-common/src/filters/combine.js [\#40](https://github.com/feathersjs/socket-commons/issues/40)
+- feathers-transport-commons produces error when it get bundled and steal-socket.io gets used as connection [\#44](https://github.com/feathersjs/transport-commons/issues/44)
+- Surface src/events.js lines 44-69 for feathers-hooks-common/src/filters/combine.js [\#40](https://github.com/feathersjs/transport-commons/issues/40)
 
 **Merged pull requests:**
 
-- Updates for Feathers v3 \(Buzzard\) [\#52](https://github.com/feathersjs/socket-commons/pull/52) ([daffl](https://github.com/daffl))
-- Rename repository and use npm scope [\#51](https://github.com/feathersjs/socket-commons/pull/51) ([daffl](https://github.com/daffl))
+- Updates for Feathers v3 \(Buzzard\) [\#52](https://github.com/feathersjs/transport-commons/pull/52) ([daffl](https://github.com/daffl))
+- Rename repository and use npm scope [\#51](https://github.com/feathersjs/transport-commons/pull/51) ([daffl](https://github.com/daffl))
 
-## [v3.0.0-pre.5](https://github.com/feathersjs/socket-commons/tree/v3.0.0-pre.5) (2017-10-18)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v3.0.0-pre.4...v3.0.0-pre.5)
-
-**Merged pull requests:**
-
-- Pass events property to the client [\#50](https://github.com/feathersjs/socket-commons/pull/50) ([daffl](https://github.com/daffl))
-
-## [v3.0.0-pre.4](https://github.com/feathersjs/socket-commons/tree/v3.0.0-pre.4) (2017-10-17)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v3.0.0-pre.3...v3.0.0-pre.4)
+## [v3.0.0-pre.5](https://github.com/feathersjs/transport-commons/tree/v3.0.0-pre.5) (2017-10-18)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v3.0.0-pre.4...v3.0.0-pre.5)
 
 **Merged pull requests:**
 
-- Fix the event name and add some channel debug statements [\#49](https://github.com/feathersjs/socket-commons/pull/49) ([daffl](https://github.com/daffl))
+- Pass events property to the client [\#50](https://github.com/feathersjs/transport-commons/pull/50) ([daffl](https://github.com/daffl))
 
-## [v3.0.0-pre.3](https://github.com/feathersjs/socket-commons/tree/v3.0.0-pre.3) (2017-10-16)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v3.0.0-pre.2...v3.0.0-pre.3)
-
-**Merged pull requests:**
-
-- Update mocha to the latest version 🚀 [\#48](https://github.com/feathersjs/socket-commons/pull/48) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
-
-## [v3.0.0-pre.2](https://github.com/feathersjs/socket-commons/tree/v3.0.0-pre.2) (2017-09-28)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v3.0.0-pre.1...v3.0.0-pre.2)
+## [v3.0.0-pre.4](https://github.com/feathersjs/transport-commons/tree/v3.0.0-pre.4) (2017-10-17)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v3.0.0-pre.3...v3.0.0-pre.4)
 
 **Merged pull requests:**
 
-- Add feathers-channels [\#47](https://github.com/feathersjs/socket-commons/pull/47) ([daffl](https://github.com/daffl))
+- Fix the event name and add some channel debug statements [\#49](https://github.com/feathersjs/transport-commons/pull/49) ([daffl](https://github.com/daffl))
 
-## [v3.0.0-pre.1](https://github.com/feathersjs/socket-commons/tree/v3.0.0-pre.1) (2017-09-08)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v2.4.0...v3.0.0-pre.1)
+## [v3.0.0-pre.3](https://github.com/feathersjs/transport-commons/tree/v3.0.0-pre.3) (2017-10-16)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v3.0.0-pre.2...v3.0.0-pre.3)
+
+**Merged pull requests:**
+
+- Update mocha to the latest version 🚀 [\#48](https://github.com/feathersjs/transport-commons/pull/48) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+
+## [v3.0.0-pre.2](https://github.com/feathersjs/transport-commons/tree/v3.0.0-pre.2) (2017-09-28)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v3.0.0-pre.1...v3.0.0-pre.2)
+
+**Merged pull requests:**
+
+- Add feathers-channels [\#47](https://github.com/feathersjs/transport-commons/pull/47) ([daffl](https://github.com/daffl))
+
+## [v3.0.0-pre.1](https://github.com/feathersjs/transport-commons/tree/v3.0.0-pre.1) (2017-09-08)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v2.4.0...v3.0.0-pre.1)
 
 **Fixed bugs:**
 
-- Socket events don't fire for sub-apps nested more than 2 deep [\#5](https://github.com/feathersjs/socket-commons/issues/5)
+- Socket events don't fire for sub-apps nested more than 2 deep [\#5](https://github.com/feathersjs/transport-commons/issues/5)
 
 **Closed issues:**
 
-- more tests [\#38](https://github.com/feathersjs/socket-commons/issues/38)
+- more tests [\#38](https://github.com/feathersjs/transport-commons/issues/38)
 
 **Merged pull requests:**
 
-- Prepare v3.0-pre [\#46](https://github.com/feathersjs/socket-commons/pull/46) ([daffl](https://github.com/daffl))
-- Update debug to the latest version 🚀 [\#45](https://github.com/feathersjs/socket-commons/pull/45) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
-- Update feathers-socketio to the latest version 🚀 [\#43](https://github.com/feathersjs/socket-commons/pull/43) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
-- Update semistandard to the latest version 🚀 [\#42](https://github.com/feathersjs/socket-commons/pull/42) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
-- Update dependencies to enable Greenkeeper 🌴 [\#41](https://github.com/feathersjs/socket-commons/pull/41) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+- Prepare v3.0-pre [\#46](https://github.com/feathersjs/transport-commons/pull/46) ([daffl](https://github.com/daffl))
+- Update debug to the latest version 🚀 [\#45](https://github.com/feathersjs/transport-commons/pull/45) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+- Update feathers-socketio to the latest version 🚀 [\#43](https://github.com/feathersjs/transport-commons/pull/43) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+- Update semistandard to the latest version 🚀 [\#42](https://github.com/feathersjs/transport-commons/pull/42) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+- Update dependencies to enable Greenkeeper 🌴 [\#41](https://github.com/feathersjs/transport-commons/pull/41) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
 
-## [v2.4.0](https://github.com/feathersjs/socket-commons/tree/v2.4.0) (2017-01-07)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v2.3.1...v2.4.0)
+## [v2.4.0](https://github.com/feathersjs/transport-commons/tree/v2.4.0) (2017-01-07)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v2.3.1...v2.4.0)
 
 **Implemented enhancements:**
 
-- support service.json [\#34](https://github.com/feathersjs/socket-commons/issues/34)
-- Socket event filters should not force returning data [\#4](https://github.com/feathersjs/socket-commons/issues/4)
-- bootstrap service.filters [\#37](https://github.com/feathersjs/socket-commons/pull/37) ([slajax](https://github.com/slajax))
+- support service.json [\#34](https://github.com/feathersjs/transport-commons/issues/34)
+- Socket event filters should not force returning data [\#4](https://github.com/feathersjs/transport-commons/issues/4)
+- bootstrap service.filters [\#37](https://github.com/feathersjs/transport-commons/pull/37) ([slajax](https://github.com/slajax))
 
 **Closed issues:**
 
-- Sockets timed out request - retry on reconnection \[feat?\] [\#32](https://github.com/feathersjs/socket-commons/issues/32)
+- Sockets timed out request - retry on reconnection \[feat?\] [\#32](https://github.com/feathersjs/transport-commons/issues/32)
 
 **Merged pull requests:**
 
-- Normalize arguments when client sends packed data. [\#39](https://github.com/feathersjs/socket-commons/pull/39) ([devel-pa](https://github.com/devel-pa))
-- Create .codeclimate.yml [\#33](https://github.com/feathersjs/socket-commons/pull/33) ([larkinscott](https://github.com/larkinscott))
-- Update feathers-commons to version 0.8.0 🚀 [\#31](https://github.com/feathersjs/socket-commons/pull/31) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
-- jshint —\> semistandard [\#30](https://github.com/feathersjs/socket-commons/pull/30) ([corymsmith](https://github.com/corymsmith))
-- Code coverage [\#29](https://github.com/feathersjs/socket-commons/pull/29) ([ekryski](https://github.com/ekryski))
+- Normalize arguments when client sends packed data. [\#39](https://github.com/feathersjs/transport-commons/pull/39) ([devel-pa](https://github.com/devel-pa))
+- Create .codeclimate.yml [\#33](https://github.com/feathersjs/transport-commons/pull/33) ([larkinscott](https://github.com/larkinscott))
+- Update feathers-commons to version 0.8.0 🚀 [\#31](https://github.com/feathersjs/transport-commons/pull/31) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- jshint —\> semistandard [\#30](https://github.com/feathersjs/transport-commons/pull/30) ([corymsmith](https://github.com/corymsmith))
+- Code coverage [\#29](https://github.com/feathersjs/transport-commons/pull/29) ([ekryski](https://github.com/ekryski))
 
-## [v2.3.1](https://github.com/feathersjs/socket-commons/tree/v2.3.1) (2016-09-02)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v2.3.0...v2.3.1)
+## [v2.3.1](https://github.com/feathersjs/transport-commons/tree/v2.3.1) (2016-09-02)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v2.3.0...v2.3.1)
 
 **Merged pull requests:**
 
-- Make service off method be namespaced [\#26](https://github.com/feathersjs/socket-commons/pull/26) ([t2t2](https://github.com/t2t2))
-- Update mocha to version 3.0.0 🚀 [\#25](https://github.com/feathersjs/socket-commons/pull/25) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- Make service off method be namespaced [\#26](https://github.com/feathersjs/transport-commons/pull/26) ([t2t2](https://github.com/t2t2))
+- Update mocha to version 3.0.0 🚀 [\#25](https://github.com/feathersjs/transport-commons/pull/25) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
 
-## [v2.3.0](https://github.com/feathersjs/socket-commons/tree/v2.3.0) (2016-07-24)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v2.2.1...v2.3.0)
+## [v2.3.0](https://github.com/feathersjs/transport-commons/tree/v2.3.0) (2016-07-24)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v2.2.1...v2.3.0)
 
 **Fixed bugs:**
 
-- Error in filter chain for 'created' event after app.authenticate\(\) [\#12](https://github.com/feathersjs/socket-commons/issues/12)
+- Error in filter chain for 'created' event after app.authenticate\(\) [\#12](https://github.com/feathersjs/transport-commons/issues/12)
 
 **Merged pull requests:**
 
-- Skip subsequent filters instead of rejecting the promise [\#24](https://github.com/feathersjs/socket-commons/pull/24) ([daffl](https://github.com/daffl))
+- Skip subsequent filters instead of rejecting the promise [\#24](https://github.com/feathersjs/transport-commons/pull/24) ([daffl](https://github.com/daffl))
 
-## [v2.2.1](https://github.com/feathersjs/socket-commons/tree/v2.2.1) (2016-07-05)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v2.2.0...v2.2.1)
+## [v2.2.1](https://github.com/feathersjs/transport-commons/tree/v2.2.1) (2016-07-05)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v2.2.0...v2.2.1)
 
-## [v2.2.0](https://github.com/feathersjs/socket-commons/tree/v2.2.0) (2016-07-05)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v2.1.0...v2.2.0)
+## [v2.2.0](https://github.com/feathersjs/transport-commons/tree/v2.2.0) (2016-07-05)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v2.1.0...v2.2.0)
 
 **Implemented enhancements:**
 
-- Support native websockets directly [\#8](https://github.com/feathersjs/socket-commons/issues/8)
+- Support native websockets directly [\#8](https://github.com/feathersjs/transport-commons/issues/8)
 
 **Fixed bugs:**
 
-- Calling `off` on primus fails [\#7](https://github.com/feathersjs/socket-commons/issues/7)
+- Calling `off` on primus fails [\#7](https://github.com/feathersjs/transport-commons/issues/7)
 
 **Closed issues:**
 
-- Should add other eventEmitter methods [\#22](https://github.com/feathersjs/socket-commons/issues/22)
-- Patch event sends the whole data back [\#21](https://github.com/feathersjs/socket-commons/issues/21)
+- Should add other eventEmitter methods [\#22](https://github.com/feathersjs/transport-commons/issues/22)
+- Patch event sends the whole data back [\#21](https://github.com/feathersjs/transport-commons/issues/21)
 
 **Merged pull requests:**
 
-- Pass all EventEmitter methods to the client connection [\#23](https://github.com/feathersjs/socket-commons/pull/23) ([daffl](https://github.com/daffl))
+- Pass all EventEmitter methods to the client connection [\#23](https://github.com/feathersjs/transport-commons/pull/23) ([daffl](https://github.com/daffl))
 
-## [v2.1.0](https://github.com/feathersjs/socket-commons/tree/v2.1.0) (2016-05-29)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v2.0.0...v2.1.0)
+## [v2.1.0](https://github.com/feathersjs/transport-commons/tree/v2.1.0) (2016-05-29)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v2.0.0...v2.1.0)
 
 **Closed issues:**
 
-- Client should convert error objects to feathers-errors [\#19](https://github.com/feathersjs/socket-commons/issues/19)
+- Client should convert error objects to feathers-errors [\#19](https://github.com/feathersjs/transport-commons/issues/19)
 
 **Merged pull requests:**
 
-- Make client convert to feathers-errors [\#20](https://github.com/feathersjs/socket-commons/pull/20) ([daffl](https://github.com/daffl))
+- Make client convert to feathers-errors [\#20](https://github.com/feathersjs/transport-commons/pull/20) ([daffl](https://github.com/daffl))
 
-## [v2.0.0](https://github.com/feathersjs/socket-commons/tree/v2.0.0) (2016-05-23)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v1.0.0...v2.0.0)
+## [v2.0.0](https://github.com/feathersjs/transport-commons/tree/v2.0.0) (2016-05-23)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v1.0.0...v2.0.0)
 
 **Merged pull requests:**
 
-- Better handling of sub-apps and sockets [\#18](https://github.com/feathersjs/socket-commons/pull/18) ([daffl](https://github.com/daffl))
-- Update babel-plugin-add-module-exports to version 0.2.0 🚀 [\#17](https://github.com/feathersjs/socket-commons/pull/17) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
-- babel-polyfill@6.7.4 breaks build 🚨 [\#16](https://github.com/feathersjs/socket-commons/pull/16) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- Better handling of sub-apps and sockets [\#18](https://github.com/feathersjs/transport-commons/pull/18) ([daffl](https://github.com/daffl))
+- Update babel-plugin-add-module-exports to version 0.2.0 🚀 [\#17](https://github.com/feathersjs/transport-commons/pull/17) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- babel-polyfill@6.7.4 breaks build 🚨 [\#16](https://github.com/feathersjs/transport-commons/pull/16) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
 
-## [v1.0.0](https://github.com/feathersjs/socket-commons/tree/v1.0.0) (2016-04-28)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v0.2.3...v1.0.0)
+## [v1.0.0](https://github.com/feathersjs/transport-commons/tree/v1.0.0) (2016-04-28)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v0.2.3...v1.0.0)
 
 **Implemented enhancements:**
 
-- Support acknowledgement timeouts [\#9](https://github.com/feathersjs/socket-commons/issues/9)
+- Support acknowledgement timeouts [\#9](https://github.com/feathersjs/transport-commons/issues/9)
 
 **Closed issues:**
 
-- Feathers over sockets is totally silent when a hook has errors [\#13](https://github.com/feathersjs/socket-commons/issues/13)
-- Listener warning when you register your own events on the socket [\#10](https://github.com/feathersjs/socket-commons/issues/10)
+- Feathers over sockets is totally silent when a hook has errors [\#13](https://github.com/feathersjs/transport-commons/issues/13)
+- Listener warning when you register your own events on the socket [\#10](https://github.com/feathersjs/transport-commons/issues/10)
 
 **Merged pull requests:**
 
-- Support timeouts for socket clients [\#15](https://github.com/feathersjs/socket-commons/pull/15) ([daffl](https://github.com/daffl))
-- Convert errors in socket callbacks [\#14](https://github.com/feathersjs/socket-commons/pull/14) ([daffl](https://github.com/daffl))
+- Support timeouts for socket clients [\#15](https://github.com/feathersjs/transport-commons/pull/15) ([daffl](https://github.com/daffl))
+- Convert errors in socket callbacks [\#14](https://github.com/feathersjs/transport-commons/pull/14) ([daffl](https://github.com/daffl))
 
-## [v0.2.3](https://github.com/feathersjs/socket-commons/tree/v0.2.3) (2016-04-16)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v0.2.2...v0.2.3)
-
-**Merged pull requests:**
-
-- Remove connection setMaxListeners [\#11](https://github.com/feathersjs/socket-commons/pull/11) ([daffl](https://github.com/daffl))
-
-## [v0.2.2](https://github.com/feathersjs/socket-commons/tree/v0.2.2) (2016-03-22)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v0.2.1...v0.2.2)
+## [v0.2.3](https://github.com/feathersjs/transport-commons/tree/v0.2.3) (2016-04-16)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v0.2.2...v0.2.3)
 
 **Merged pull requests:**
 
-- Allow chaining event listeners. [\#6](https://github.com/feathersjs/socket-commons/pull/6) ([joshuajabbour](https://github.com/joshuajabbour))
+- Remove connection setMaxListeners [\#11](https://github.com/feathersjs/transport-commons/pull/11) ([daffl](https://github.com/daffl))
 
-## [v0.2.1](https://github.com/feathersjs/socket-commons/tree/v0.2.1) (2016-03-08)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v0.2.0...v0.2.1)
-
-**Merged pull requests:**
-
-- Set connection max listeners and better debug messages [\#3](https://github.com/feathersjs/socket-commons/pull/3) ([daffl](https://github.com/daffl))
-
-## [v0.2.0](https://github.com/feathersjs/socket-commons/tree/v0.2.0) (2016-02-08)
-[Full Changelog](https://github.com/feathersjs/socket-commons/compare/v0.1.0...v0.2.0)
+## [v0.2.2](https://github.com/feathersjs/transport-commons/tree/v0.2.2) (2016-03-22)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v0.2.1...v0.2.2)
 
 **Merged pull requests:**
 
-- Query params [\#2](https://github.com/feathersjs/socket-commons/pull/2) ([ekryski](https://github.com/ekryski))
-- Adding nsp check [\#1](https://github.com/feathersjs/socket-commons/pull/1) ([marshallswain](https://github.com/marshallswain))
+- Allow chaining event listeners. [\#6](https://github.com/feathersjs/transport-commons/pull/6) ([joshuajabbour](https://github.com/joshuajabbour))
 
-## [v0.1.0](https://github.com/feathersjs/socket-commons/tree/v0.1.0) (2016-01-21)
+## [v0.2.1](https://github.com/feathersjs/transport-commons/tree/v0.2.1) (2016-03-08)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v0.2.0...v0.2.1)
+
+**Merged pull requests:**
+
+- Set connection max listeners and better debug messages [\#3](https://github.com/feathersjs/transport-commons/pull/3) ([daffl](https://github.com/daffl))
+
+## [v0.2.0](https://github.com/feathersjs/transport-commons/tree/v0.2.0) (2016-02-08)
+[Full Changelog](https://github.com/feathersjs/transport-commons/compare/v0.1.0...v0.2.0)
+
+**Merged pull requests:**
+
+- Query params [\#2](https://github.com/feathersjs/transport-commons/pull/2) ([ekryski](https://github.com/ekryski))
+- Adding nsp check [\#1](https://github.com/feathersjs/transport-commons/pull/1) ([marshallswain](https://github.com/marshallswain))
+
+## [v0.1.0](https://github.com/feathersjs/transport-commons/tree/v0.1.0) (2016-01-21)
 
 
 \* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# @feathersjs/socket-commons
+# @feathersjs/transport-commons
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/feathersjs/socket-commons.svg)](https://greenkeeper.io/)
+[![Greenkeeper badge](https://badges.greenkeeper.io/feathersjs/transport-commons.svg)](https://greenkeeper.io/)
 
-[![Build Status](https://travis-ci.org/feathersjs/socket-commons.png?branch=master)](https://travis-ci.org/feathersjs/socket-commons)
-[![Test Coverage](https://codeclimate.com/github/feathersjs/socket-commons/badges/coverage.svg)](https://codeclimate.com/github/feathersjs/socket-commons/coverage)
-[![Dependency Status](https://img.shields.io/david/feathersjs/socket-commons.svg?style=flat-square)](https://david-dm.org/feathersjs/socket-commons)
-[![Download Status](https://img.shields.io/npm/dm/@feathersjs/socket-commons.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/socket-commons)
+[![Build Status](https://travis-ci.org/feathersjs/transport-commons.png?branch=master)](https://travis-ci.org/feathersjs/transport-commons)
+[![Test Coverage](https://codeclimate.com/github/feathersjs/transport-commons/badges/coverage.svg)](https://codeclimate.com/github/feathersjs/transport-commons/coverage)
+[![Dependency Status](https://img.shields.io/david/feathersjs/transport-commons.svg?style=flat-square)](https://david-dm.org/feathersjs/transport-commons)
+[![Download Status](https://img.shields.io/npm/dm/@feathersjs/transport-commons.svg?style=flat-square)](https://www.npmjs.com/package/@feathersjs/transport-commons)
 
-> Shared functionality for websocket providers like [@feathers/socketio](https://github.com/feathersjs/socketio) and [@feathersjs/primus](https://github.com/feathersjs/primus). Only intended to be used internally by other Feathers real-time providers.
+> Shared functionality for Feathers API transports like [@feathers/socketio](https://github.com/feathersjs/socketio) and [@feathersjs/primus](https://github.com/feathersjs/primus). Only intended to be used internally.
 
 ## About
 
-`@feathersjs/socket-commons` contains internal shared functionality for Feathers real-time providers (currently Socket.io and Primus).
+`@feathersjs/transport-commons` contains internal shared functionality for Feathers real-time providers (currently Socket.io and Primus).
 
 `lib/client.js` is a base socket service client
 `lib/index.js` returns a configurable function and requires the following options:
@@ -26,7 +26,7 @@
 Channels provide channel functionality for bi-directional Feathers service providers. It is e.g. used by the Socket.io and Primus provider to quickly determine what messages to send to connected clients.
 
 ```
-const channels = require('@feathersjs/socket-commons/lib/channels');
+const channels = require('@feathersjs/transport-commons/lib/channels');
 ```
 
 ## Documentation
@@ -111,6 +111,6 @@ app.on('publish', (event, channel, hook) => {
 
 ## License
 
-Copyright (c) 2015
+Copyright (c) 2018
 
 Licensed under the [MIT license](LICENSE).

--- a/lib/channels/index.js
+++ b/lib/channels/index.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('@feathersjs/socket-commons/channels');
+const debug = require('debug')('@feathersjs/transport-commons/channels');
 const { get, compact, flattenDeep, noop } = require('lodash');
 const CombinedChannel = require('./channel/combined');
 const { channelMixin, publishMixin, keys } = require('./mixins');

--- a/lib/channels/mixins.js
+++ b/lib/channels/mixins.js
@@ -1,10 +1,10 @@
-const debug = require('debug')('@feathersjs/socket-commons:channels/mixins');
+const debug = require('debug')('@feathersjs/transport-commons:channels/mixins');
 const Channel = require('./channel/base');
 const CombinedChannel = require('./channel/combined');
 
-const PUBLISHERS = Symbol('@feathersjs/socket-commons/publishers');
-const CHANNELS = Symbol('@feathersjs/socket-commons/channels');
-const ALL_EVENTS = Symbol('@feathersjs/socket-commons/all-events');
+const PUBLISHERS = Symbol('@feathersjs/transport-commons/publishers');
+const CHANNELS = Symbol('@feathersjs/transport-commons/channels');
+const ALL_EVENTS = Symbol('@feathersjs/transport-commons/all-events');
 
 exports.keys = {
   PUBLISHERS,

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,5 @@
 const { convert } = require('@feathersjs/errors');
-const debug = require('debug')('@feathersjs/socket-commons/client');
+const debug = require('debug')('@feathersjs/transport-commons/client');
 
 const namespacedEmitterMethods = [
   'addListener',

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('@feathersjs/socket-commons');
+const debug = require('debug')('@feathersjs/transport-commons');
 const channels = require('./channels');
 const routing = require('./routing');
 const { getDispatcher, runMethod } = require('./utils');

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -1,6 +1,6 @@
 const Router = require('radix-router');
 const { stripSlashes } = require('@feathersjs/commons');
-const ROUTER = Symbol('@feathersjs/socket-commons/router');
+const ROUTER = Symbol('@feathersjs/transport-commons/router');
 
 module.exports = function () {
   return app => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 const errors = require('@feathersjs/errors');
-const debug = require('debug')('@feathersjs/socket-commons');
+const debug = require('debug')('@feathersjs/transport-commons');
 
 const paramsPositions = exports.paramsPositions = {
   find: 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@feathersjs/socket-commons",
+  "name": "@feathersjs/transport-commons",
   "version": "3.1.5",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@feathersjs/socket-commons",
+  "name": "@feathersjs/transport-commons",
   "description": "Shared functionality for websocket providers",
   "version": "3.1.5",
-  "homepage": "https://github.com/feathersjs/socket-commons",
+  "homepage": "https://github.com/feathersjs/transport-commons",
   "main": "lib/",
   "keywords": [
     "feathers",
@@ -11,7 +11,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/feathersjs/socket-commons.git"
+    "url": "git://github.com/feathersjs/transport-commons.git"
   },
   "author": {
     "name": "Feathers contributors",
@@ -20,7 +20,7 @@
   },
   "contributors": [],
   "bugs": {
-    "url": "https://github.com/feathersjs/socket-commons/issues"
+    "url": "https://github.com/feathersjs/transport-commons/issues"
   },
   "engines": {
     "node": ">= 6"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,7 +4,7 @@ const feathers = require('@feathersjs/feathers');
 
 const commons = require('../lib');
 
-describe('@feathersjs/socket-commons', () => {
+describe('@feathersjs/transport-commons', () => {
   let provider, options, app, connection;
 
   beforeEach(() => {


### PR DESCRIPTION
Since this will contain shared utilities for any future Feathers API providers not just websockets.