### PR TITLE
Pass connection in params

### DIFF
--- a/lib/socket/utils.js
+++ b/lib/socket/utils.js
@@ -86,7 +86,7 @@ exports.runMethod = function (app, connection, path, method, args) {
     const query = methodArgs[position] || {};
     // `params` have to be re-mapped to the query
     // and added with the route
-    const params = Object.assign({ query, route }, connection);
+    const params = Object.assign({ query, route, connection }, connection);
 
     methodArgs[position] = params;
 

--- a/test/socket/index.test.js
+++ b/test/socket/index.test.js
@@ -58,7 +58,8 @@ describe('@feathersjs/transport-commons', () => {
             id: 10,
             params: Object.assign({
               query: {},
-              route: {}
+              route: {},
+              connection
             }, connection)
           });
           done();
@@ -82,7 +83,8 @@ describe('@feathersjs/transport-commons', () => {
         try {
           const params = Object.assign({
             query: { fromQuery: true },
-            route: {}
+            route: {},
+            connection
           }, connection);
 
           assert.ok(!error);
@@ -107,6 +109,7 @@ describe('@feathersjs/transport-commons', () => {
           assert.deepEqual(result, {
             id: 10,
             params: Object.assign({
+              connection,
               query: {},
               route: {}
             }, connection)
@@ -131,7 +134,8 @@ describe('@feathersjs/transport-commons', () => {
       }, (error, result) => {
         const params = Object.assign({
           query: { fromQuery: true },
-          route: {}
+          route: {},
+          connection
         }, connection);
 
         try {

--- a/test/socket/utils.test.js
+++ b/test/socket/utils.test.js
@@ -167,6 +167,36 @@ describe('socket commons utils', () => {
         runMethod(app, {}, 'myservice', 'get', [ 10, {}, callback ]);
       });
 
+      it('merges params with connection and passes connection', done => {
+        const connection = {
+          testing: true
+        };
+        const callback = (error, result) => {
+          if (error) {
+            return done(error);
+          }
+
+          assert.deepEqual(result, {
+            id: 10,
+            params: {
+              connection,
+              query: {},
+              route: {},
+              testing: true
+            }
+          });
+          done();
+        };
+
+        app.use('/otherservice', {
+          get (id, params) {
+            return Promise.resolve({ id, params });
+          }
+        });
+
+        runMethod(app, connection, 'otherservice', 'get', [ 10, {}, callback ]);
+      });
+
       it('with params missing', done => {
         const callback = (error, result) => {
           if (error) {


### PR DESCRIPTION
Sometimes the connection may be required in the service call. Specifically this relates to https://github.com/feathersjs/authentication/issues/517 since it will allow to update the connection once an access token has been created.