### PR TITLE
Throw a Timeout error on send timeout instead of Error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,4 +1,4 @@
-const { convert } = require('@feathersjs/errors');
+const { convert, Timeout } = require('@feathersjs/errors');
 const debug = require('debug')('@feathersjs/transport-commons/client');
 
 const namespacedEmitterMethods = [
@@ -63,7 +63,11 @@ module.exports = class Service {
   send (method, ...args) {
     return new Promise((resolve, reject) => {
       const timeoutId = setTimeout(() => reject(
-        new Error(`Timeout of ${this.timeout}ms exceeded calling ${method} on ${this.path}`)
+        new Timeout(`Timeout of ${this.timeout}ms exceeded calling ${method} on ${this.path}`, {
+          timeout: this.timeout,
+          method,
+          path: this.path
+        })
       ), this.timeout);
 
       args.unshift(method, this.path);

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -130,6 +130,14 @@ describe('client', () => {
     );
   });
 
+  it('throws a Timeout error when send times out waiting for a response', () => {
+    return service.remove(10).then(() => {
+      throw new Error('Should never get here');
+    }).catch(error =>
+      assert.equal(error.name, 'Timeout')
+    );
+  });
+
   it('converts to feathers-errors (#19)', () => {
     connection.once('create', (path, data, params, callback) =>
       callback(new errors.NotAuthenticated('Test', { hi: 'me' }).toJSON())


### PR DESCRIPTION
Make it easier for upstream callers to detect the error type/originator of a send timeout.

error.type = 'FeathersError'
error.name = 'Timeout'