### PR TITLE
Remove empty channels

### DIFF
--- a/lib/channels/channel/base.js
+++ b/lib/channels/channel/base.js
@@ -1,5 +1,9 @@
-class Channel {
+const { EventEmitter } = require('events');
+
+class Channel extends EventEmitter {
   constructor (connections = [], data = null) {
+    super();
+
     this.connections = connections;
     this.data = data;
   }
@@ -20,6 +24,10 @@ class Channel {
         this.connections.splice(index, 1);
       }
     });
+
+    if (this.length === 0) {
+      this.emit('empty');
+    }
 
     return this;
   }

--- a/lib/channels/mixins.js
+++ b/lib/channels/mixins.js
@@ -24,14 +24,24 @@ exports.channelMixin = function channelMixin () {
       }
 
       if (names.length === 1) {
-        const name = names[0];
+        const [ name ] = names;
 
         if (Array.isArray(name)) {
           return this.channel(...name);
         }
 
-        return this[CHANNELS][name] ||
-          (this[CHANNELS][name] = new Channel());
+        if (!this[CHANNELS][name]) {
+          const channel = new Channel();
+
+          channel.once('empty', () => {
+            channel.removeAllListeners();
+            delete this[CHANNELS][name];
+          });
+
+          this[CHANNELS][name] = channel;
+        }
+
+        return this[CHANNELS][name];
       }
 
       const channels = names.map(name => this.channel(name));


### PR DESCRIPTION
This pull request removes a channel into an event emitter and adds an `empty` event. It allows to remove the channel from the application once it is empty. Channel objects are pretty small but it makes sense to remove them once they are not used anymore so that we are not leaking memory in applications that create many temporary channels.

Closes https://github.com/feathersjs/docs/issues/1154