### PR TITLE
Fix looking up invalid path names through sockets

### DIFF
--- a/lib/routing.js
+++ b/lib/routing.js
@@ -13,7 +13,11 @@ module.exports = function () {
     Object.assign(app, {
       [ROUTER]: router,
       lookup (path) {
-        return this[ROUTER].lookup(stripSlashes(path));
+        if (!path) {
+          return null;
+        }
+
+        return this[ROUTER].lookup(stripSlashes('' + path));
       }
     });
 

--- a/test/routing.test.js
+++ b/test/routing.test.js
@@ -30,6 +30,11 @@ describe('app.router', () => {
     assert.equal(result, null);
   });
 
+  it('returns null for invalid service path', () => {
+    assert.equal(app.lookup(null), null);
+    assert.equal(app.lookup({}), null);
+  });
+
   it('can look up and strips slashes', () => {
     const result = app.lookup('my/service');
 

--- a/test/socket/index.test.js
+++ b/test/socket/index.test.js
@@ -69,6 +69,18 @@ describe('@feathersjs/transport-commons', () => {
       });
     });
 
+    it('.get with invalid service name and arguments', done => {
+      const socket = new EventEmitter();
+
+      provider.emit('connection', socket);
+
+      socket.emit('get', null, (error, result) => {
+        assert.equal(error.name, 'NotFound');
+        assert.equal(error.message, `Service 'null' not found`);
+        done();
+      });
+    });
+
     it('.create with params', done => {
       const socket = new EventEmitter();
       const data = {


### PR DESCRIPTION
Making sure that invalid path names throw the proper error.

Related to https://github.com/feathersjs-ecosystem/feathers-swift/issues/25